### PR TITLE
Save Camera Transform to Avoid Issues with Saving World the Camera is in

### DIFF
--- a/Assets/Scripts/Flow/PlayerPositioner.cs
+++ b/Assets/Scripts/Flow/PlayerPositioner.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class PlayerPositioner : MonoBehaviour
@@ -13,7 +11,7 @@ public class PlayerPositioner : MonoBehaviour
     Vector3 spawnPosition;
     Quaternion spawnRotation;
 
-    // For game testing purposes run these console commands on spawn in
+    // For game testing purposes run these console commands on spawn in if we are in editor
     public string[] consoleCommands;
 
     void Start()

--- a/Assets/Scripts/SavingPersistence/PlayerSaveDataManager.cs
+++ b/Assets/Scripts/SavingPersistence/PlayerSaveDataManager.cs
@@ -1,3 +1,4 @@
+using Cinemachine;
 using UnityEngine;
 
 public class PlayerSaveDataManager : MonoBehaviour
@@ -192,6 +193,10 @@ public class PlayerSaveDataManager : MonoBehaviour
         {
             PortalManager.instance.Swap();
         }
+
+        var cameraBrain = FindObjectOfType<CinemachineBrain>();
+        var virtualCamera = cameraBrain.ActiveVirtualCamera as CinemachineVirtualCameraBase;
+        virtualCamera.ForceCameraPosition(worldData.cameraPosition.toVector3(), worldData.cameraRotation.toQuaternion());
     }
 
     public static void Clear()

--- a/Assets/Scripts/SavingPersistence/PlayerWorldData.cs
+++ b/Assets/Scripts/SavingPersistence/PlayerWorldData.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -10,13 +8,17 @@ public class PlayerWorldData
     public string activeScene;
     public float[] position;
     public float[] rotation;
+    public float[] cameraPosition;
+    public float[] cameraRotation;
     public bool inWorld2;
 
     public void GetWorldData(PortalManager portal, PlayerActor player)
     {
         inWorld2 = portal.inWorld2;
-        position = new float[] { player.transform.position.x , player.transform.position.y, player.transform.position.z };
-        rotation = new float[] { player.transform.rotation.x, player.transform.rotation.y, player.transform.rotation.z, player.transform.rotation.w };
+        position = player.transform.position.toFloatArray();
+        rotation = player.transform.rotation.toFloatArray();
+        cameraPosition = Camera.main.transform.position.toFloatArray();
+        cameraRotation = Camera.main.transform.rotation.toFloatArray();
         activeScene = SceneManager.GetActiveScene().name;
     }
 }

--- a/Assets/Scripts/SavingPersistence/SerializationExtensions.cs
+++ b/Assets/Scripts/SavingPersistence/SerializationExtensions.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+// Quaternions and Vectors half self referential properties
+// so we convert them to float[] for storage
+public static class SerializationExtensions
+{
+    public static float[] toFloatArray(this Quaternion quaternion)
+    {
+        return new float[] { quaternion.x, quaternion.y, quaternion.z, quaternion.w };
+    }
+
+    public static Quaternion toQuaternion(this float[] quaternion_components)
+    {
+        return new Quaternion(quaternion_components[0], quaternion_components[1], quaternion_components[2], quaternion_components[3]);
+    }
+
+    public static float[] toFloatArray(this Vector3 vector)
+    {
+        return new float[] { vector.x, vector.y, vector.z };
+    }
+
+    public static Vector3 toVector3(this float[] vector_components)
+    {
+        return new Vector3(vector_components[0], vector_components[1], vector_components[2]);
+    }
+}

--- a/Assets/Scripts/SavingPersistence/SerializationExtensions.cs.meta
+++ b/Assets/Scripts/SavingPersistence/SerializationExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd4a746f2504f084eb74109a97daf683
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/Portals/PortalCamera.cs
+++ b/Assets/Scripts/World/Portals/PortalCamera.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class PortalCamera : MonoBehaviour
@@ -7,7 +5,7 @@ public class PortalCamera : MonoBehaviour
     PortalManager manager;
     Camera camera;
     bool updateTex;
-    // Start is called before the first frame update
+
     void Start()
     {
         manager = PortalManager.instance;

--- a/Assets/Scripts/World/Portals/PortalManager.cs
+++ b/Assets/Scripts/World/Portals/PortalManager.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 

--- a/Assets/Scripts/World/Portals/PortalPlane.cs
+++ b/Assets/Scripts/World/Portals/PortalPlane.cs
@@ -15,11 +15,11 @@ public class PortalPlane : MonoBehaviour
     [ReadOnly, SerializeField] private bool nearPlaneClipping;
     public float camErrorDist = 0.75f;
     public float range = 10f;
-    // Start is called before the first frame update
+
     void Start()
     {
-        plane = new Plane(this.transform.up, this.transform.position);
-        renderer = this.GetComponent<Renderer>();
+        plane = new Plane(transform.up, transform.position);
+        renderer = GetComponent<Renderer>();
         bounds = renderer.bounds;
     }
 
@@ -27,11 +27,11 @@ public class PortalPlane : MonoBehaviour
     {
         CheckPortalPlane();
     }
+
     void CheckPortalPlane()
     {
-        
-        if (this.gameObject.scene != SceneManager.GetActiveScene()) return;
-        withinBounds = Vector3.Distance(PlayerActor.player.transform.position, this.transform.position) < range || Vector3.Distance(Camera.main.transform.position, this.transform.position) < range;//IsWithinPlane(PlayerActor.player.transform.position);// IsWithinPlane(Camera.main.transform.position + Camera.main.nearClipPlane * Camera.main.transform.forward);
+        if (gameObject.scene != SceneManager.GetActiveScene()) return;
+        withinBounds = Vector3.Distance(PlayerActor.player.transform.position, transform.position) < range || Vector3.Distance(Camera.main.transform.position, transform.position) < range;//IsWithinPlane(PlayerActor.player.transform.position);// IsWithinPlane(Camera.main.transform.position + Camera.main.nearClipPlane * Camera.main.transform.forward);
         bool swap = false;
         bool render = true;
         if (withinBounds)
@@ -78,11 +78,9 @@ public class PortalPlane : MonoBehaviour
 
     bool IsWithinPlane(Vector3 position)
     {
-        Ray posray = new Ray(position, this.transform.up);
-        Ray negray = new Ray(position, -this.transform.up);
-        bool intersect = false;
-
-        intersect = bounds.IntersectRay(posray) || bounds.IntersectRay(negray);
+        Ray posray = new Ray(position, transform.up);
+        Ray negray = new Ray(position, -transform.up);
+        bool intersect = bounds.IntersectRay(posray) || bounds.IntersectRay(negray);
         return intersect;
     }
 
@@ -100,11 +98,5 @@ public class PortalPlane : MonoBehaviour
     {
         float distToPlane = Mathf.Abs(plane.GetDistanceToPoint(Camera.main.transform.position));
         return (distToPlane < camErrorDist) && IsWithinPlane(Camera.main.transform.position);
-        Vector3 min = Camera.main.ScreenToWorldPoint(new Vector3(0, 0, 0f));
-        Vector3 max = Camera.main.ScreenToWorldPoint(new Vector3(Camera.main.pixelWidth, Camera.main.pixelHeight, Camera.main.nearClipPlane));
-        Bounds camBounds = new Bounds();
-        camBounds.SetMinMax(min, max);
-        bool intersect = bounds.Intersects(camBounds);
-        return intersect;
     }
 }


### PR DESCRIPTION
Previously you could end up with the wrong camera culling mask because the camera would move to its default state. If you did this close to a portal it could move your camera through the portal without swapping worlds. Saving and restoring the camera state on save/load is the easy fix that is also just nice to have in the game.